### PR TITLE
update tar-fs

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "extend": "~1.2.1",
     "progress": "~1.1.2",
     "rimraf": "~2.2.4",
-    "tar-fs": "~0.1.4",
+    "tar-fs": "~0.3.2",
     "request": "~2.27.0"
   },
   "repository": {


### PR DESCRIPTION
time to update tar-fs to the latest version. 0.3.2 contains various fixes and doesn't have any breaking changes in regards to folder-backup
