### PR TITLE
make sure fbackup.serve callback gets called

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,6 +66,6 @@ function serve(dir, httpResponse, cb) {
     httpResponse.setHeader('x-file-count', files.length)
     var gzip = zlib.createGzip()
     packStream.pipe(gzip).pipe(httpResponse)
-    if (cb) httpResponse.on('end', cb)
+    if (cb) httpResponse.on('finish', cb)
   })
 }

--- a/test/test.js
+++ b/test/test.js
@@ -6,9 +6,10 @@ var fs = require('fs')
 var fbackup = require('../')
 
 test('basic', function(t) {
+  t.plan(3);
   var target = path.join(__dirname, 'target')
   rimraf(target, function(err) {
-    var server = serve()
+    var server = serve(t)
     server.listen(8080, function(err) {
       if (err) throw err
       fbackup.clone('http://localhost:8080', { path: target }, function(err) {
@@ -24,8 +25,10 @@ test('basic', function(t) {
   })
 })
 
-function serve() {
+function serve(t) {
   return http.createServer(function(req, res) {
-    fbackup.serve(__dirname, res, function(err) {})
+    fbackup.serve(__dirname, res, function(err) {
+      t.notOk(err, 'no serve error')
+    })
   })
 }


### PR DESCRIPTION
the `fbackup.serve` callback doesn't get called because the `end` event for a `httpResponse` object never fires, it should be `finish` as it's a `Writable` stream.

This also fixes a bug with `hyperlevel-backup` where the folder never gets removed after being served over HTTP.
